### PR TITLE
Make pry an optional dependency

### DIFF
--- a/lib/master_to_main/cli.rb
+++ b/lib/master_to_main/cli.rb
@@ -1,5 +1,8 @@
 require "thor"
-require "pry"
+begin
+  require "pry"
+rescue LoadError
+end
 require "octokit"
 
 module MasterToMain

--- a/master_to_main.gemspec
+++ b/master_to_main.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 


### PR DESCRIPTION
I don't see pry actually being used in the code, but I figured the require was in there because it had been useful as a development tool. Alternatively, you could scrap these changes and just remove the `require "pry"`.