### PR TITLE
[Bugfix] Update match for enterprise GH URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Fixup issue where public Github URLs would result in a `NilClass` error. (thanks @hollabaq86)
+
 # 0.0.7 - 2020-06-24
 
 - Remove forgotten pry requirement

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 - [@woodbusy](https://github.com/woodbusy)
+- [@hollabaq86](https://github.com/hollabaq86)

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ After filling out the relevant prompts you will be able to:
 
 You will be prompted for:
 
-1. Your "github" (e.g. "github.com" or "github.mycompany.com", default is based
+1. The "github" (e.g. "github.com" or "github.mycompany.com", default is based
 on Fetch URL of `origin` or "github.com")
-1. Your user (default is based on Fetch URL of `origin` or `whoami`)
+1. The parent user/organization (default is based on Fetch URL of `origin` or `whoami`, which may be different if the repo is owned by an organization)
 1. The repository you want to update (default is based on Fetch URL of `origin`
 or `pwd`)
 1. The current default branch (default is `master`)

--- a/lib/master_to_main/cli.rb
+++ b/lib/master_to_main/cli.rb
@@ -66,7 +66,8 @@ module MasterToMain
 
       def get_github_info
         fetch_url = `git remote show origin | grep "Fetch URL"`
-        if fetch_url != ""
+        #GH Enterprise URLs include a semicolon that public URLs do not
+        if fetch_url.match(/com:/)
           base = fetch_url.split("github.")[1]
           github_suffix, user_repo = base.split(":")
           user, repo = user_repo.split("/")


### PR DESCRIPTION
👋  When trying to use the gem for a public GitHub repo, I encountered the following error:

```
Traceback (most recent call last):
	9: from /usr/local/bin/master_to_main:23:in `<main>'
	8: from /usr/local/bin/master_to_main:23:in `load'
	7: from /Library/Ruby/Gems/2.6.0/gems/master_to_main-0.0.7/exe/master_to_main:5:in `<top (required)>'
	6: from /Library/Ruby/Gems/2.6.0/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
	5: from /Library/Ruby/Gems/2.6.0/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
	4: from /Library/Ruby/Gems/2.6.0/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
	3: from /Library/Ruby/Gems/2.6.0/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
	2: from /Library/Ruby/Gems/2.6.0/gems/master_to_main-0.0.7/lib/master_to_main/cli.rb:14:in `update'
	1: from /Library/Ruby/Gems/2.6.0/gems/master_to_main-0.0.7/lib/master_to_main/cli.rb:89:in `prompt_info'
/Library/Ruby/Gems/2.6.0/gems/master_to_main-0.0.7/lib/master_to_main/cli.rb:72:in `get_github_info': undefined method `split' for nil:NilClass (NoMethodError)
```

On investigation, current behavior is expecting a `:` in the URL of the repo being updated, which isn't the case for public-facing repos (i.e. `github.com/dewyze/master_to_main`).

This PR:
- fixes up this issue with a match statement (I though a specific check for `com:` would be enough to differentiate between GHE URLs and public domains)
- Clarifies the documentation a bit (I got a little confused updating repos that are owned by an organization and not me)
- Updates the CHANGELOG and CONTRIBUTORs files.

Thanks for making this gem!

